### PR TITLE
Add pytest step to update_geojson workflow

### DIFF
--- a/.github/workflows/update_geojson.yml
+++ b/.github/workflows/update_geojson.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Instalar dependencias
         run: pip install pandas requests shapely
 
+      - name: Ejecutar pruebas
+        run: pytest
+
       - name: Actualizar GeoJSON
         run: python update_geojson.py
 


### PR DESCRIPTION
## Summary
- ensure update_geojson workflow runs tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846b30e49c0832eac2dc3ac82c7b6c2