### PR TITLE
Read sheet id from environment

### DIFF
--- a/.github/workflows/update_geojson.yml
+++ b/.github/workflows/update_geojson.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      SHEET_ID: ${{ secrets.SHEET_ID }}
     steps:
       - uses: actions/checkout@v4
 

--- a/update_geojson.py
+++ b/update_geojson.py
@@ -1,4 +1,5 @@
 # update_geojson.py
+import os
 import pandas as pd
 import requests
 import json
@@ -6,8 +7,15 @@ from shapely import wkt
 import shapely.geometry
 
 # URL para exportar tu sheet como CSV
-SHEET_ID = '1Vy5PuzBZwBlg4r4mIK98eX0_NfDpTTRVkxvXL_tVGuw'
-CSV_URL = f"https://docs.google.com/spreadsheets/d/{SHEET_ID}/export?format=csv"
+# Permite sobrescribir usando variables de entorno
+SHEET_ID = os.getenv(
+    "SHEET_ID",
+    "1Vy5PuzBZwBlg4r4mIK98eX0_NfDpTTRVkxvXL_tVGuw",
+)
+CSV_URL = os.getenv(
+    "CSV_URL",
+    f"https://docs.google.com/spreadsheets/d/{SHEET_ID}/export?format=csv",
+)
 
 # Función que transforma cada registro del Sheet a un Feature GeoJSON
 def row_to_geojson_feature(row):


### PR DESCRIPTION
## Summary
- allow configuring the spreadsheet URL through `SHEET_ID` or `CSV_URL` environment variables
- configure workflow to provide the sheet id via GitHub secret

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846b31c1bbc832eaf4514b59e02410c