### PR TITLE
Add reusable setup script

### DIFF
--- a/.github/workflows/update_geojson.yml
+++ b/.github/workflows/update_geojson.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'pip'
 
       - name: Instalar dependencias
-        run: pip install -r requirements.txt
+        run: ./setup.sh
 
       - name: Ejecutar pruebas
         run: pytest

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Si tienes preguntas, puedes contactarme en `tuemail@example.com`. 🚀
 Para ejecutar la suite de tests con **pytest**:
 
 ```bash
-pip install -r requirements.txt  # instala las dependencias
+./setup.sh        # instala las dependencias
 pytest
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- add setup.sh for installing requirements
- reference setup script in README for running tests
- use setup.sh in GitHub Actions workflow

## Testing
- `./setup.sh` *(fails: Could not find a version that satisfies the requirement geopandas)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6846bf8efee0832e9d00bce87ec035a0