### PR TITLE
Add setup script and unify instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ geoportal-rpas-amaya/
 Si tienes preguntas, puedes contactarme en `tuemail@example.com`. 🚀
 
 ## 🧪 Pruebas
-Para ejecutar la suite de tests con **pytest**:
+Antes de ejecutar la suite de tests con **pytest**, ejecuta `./setup.sh` para instalar las dependencias:
 
 ```bash
 ./setup.sh        # instala las dependencias


### PR DESCRIPTION
## Summary
- clarify that `./setup.sh` should be run before tests
- ensure setup script is executable and reusable in workflow

## Testing
- `./setup.sh` *(fails: Could not install dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846c0ee8024832eb04d1d20d51e3b00