### PR TITLE
Ensure newline at EOF for map.js

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -23,3 +23,4 @@ L.control.layers({
   "Mapa": osm,
   "Satélite": satelite
 }).addTo(mapa);
+


### PR DESCRIPTION
## Summary
- ensure `js/map.js` ends with a newline character

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846c3184b5c832eac79f3ba9c2b78d7