### PR TITLE
Configure workflow to open PR for geojson update

### DIFF
--- a/.github/workflows/update_geojson.yml
+++ b/.github/workflows/update_geojson.yml
@@ -29,13 +29,18 @@ jobs:
       - name: Actualizar GeoJSON
         run: python update_geojson.py
 
-      - name: Sincronizar con la rama remota
-        run: git pull --ff-only
-
-      - name: Commit y push cambios
+      - name: Commit cambios
         run: |
           git config --global user.name 'github-actions'
           git config --global user.email 'actions@github.com'
           git add Poligonos_RPAS.json
           git commit -m "Actualización automática del GeoJSON (.json)" || echo "Sin cambios"
-          git push
+
+      - name: Crear Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Actualización automática del GeoJSON (.json)"
+          title: "Actualización automática del GeoJSON"
+          body: "Este PR actualiza el archivo Poligonos_RPAS.json con los datos más recientes del Sheet."
+          branch: auto/update-geojson


### PR DESCRIPTION
## Summary
- modify the update workflow to open a pull request rather than pushing to the main branch

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846c4e6d310832e8dbd4b09fbe40c17