### PR TITLE
Update README with local data info

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ geoportal-rpas-amaya/
 
 > **Nota:** Leaflet se carga desde un CDN y no está incluido en la carpeta `js`.
 
+## 📊 Datos
+
+Los polígonos de vuelo se almacenan en `Geodatabase/Geodatabase.csv`. El script
+`update_geojson.py` ya **no** descarga la información de Google Sheets, sino que
+lee ese archivo para generar `Poligonos_RPAS.json`. La acción de GitHub que
+mantiene actualizado el repositorio se apoya en ese CSV local.
+
 ## 🛠 Tecnologías Utilizadas
 - **HTML5**
 - **CSS3**


### PR DESCRIPTION
## Summary
- document that data is stored in `Geodatabase/Geodatabase.csv`
- explain that `update_geojson.py` works from this CSV and the GitHub Action uses it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6847ea83becc832e9d1a1f463a9f5677