### PR TITLE
Update README on CSV usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Este es un proyecto web que muestra un mapa interactivo con misiones de vuelo co
 Los registros de misiones se encuentran en `Geodatabase/Geodatabase.csv`.
 El script `update_geojson.py` genera el archivo `Poligonos_RPAS.json` a partir de este CSV.
 La acción de GitHub usa solo este archivo local y ya no descarga datos de Google Sheets.
+Otros archivos CSV, como el exportado manualmente desde Google, se omiten por completo durante la ejecución del workflow.
 
 ## 📂 Estructura del Proyecto
 ```


### PR DESCRIPTION
## Summary
- document that the GitHub Actions workflow uses `Geodatabase/Geodatabase.csv` and ignores other CSV files

## Testing
- `./setup.sh`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684863979a08832e85c7f6718be2509c