### PR TITLE
Allow merging to replace features with same name

### DIFF
--- a/tests/test_update_geojson.py
+++ b/tests/test_update_geojson.py
@@ -35,13 +35,13 @@ def test_row_to_geojson_feature_returns_valid_geojson():
     assert 'properties' in feature
 
 
-def test_merge_features_adds_new_and_skips_existing():
+def test_merge_features_adds_new_and_replaces_existing():
     existing = [
-        {"type": "Feature", "properties": {"Nombre": "A"}},
-        {"type": "Feature", "properties": {"Nombre": "B"}},
+        {"type": "Feature", "properties": {"Nombre": "A", "v": 1}},
+        {"type": "Feature", "properties": {"Nombre": "B", "old": True}},
     ]
     new = [
-        {"type": "Feature", "properties": {"Nombre": "B"}},
+        {"type": "Feature", "properties": {"Nombre": "B", "old": False}},
         {"type": "Feature", "properties": {"Nombre": "C"}},
     ]
 
@@ -49,6 +49,7 @@ def test_merge_features_adds_new_and_skips_existing():
     nombres = [f["properties"]["Nombre"] for f in merged]
 
     assert nombres == ["A", "B", "C"]
+    assert merged[1]["properties"]["old"] is False
 
 
 def test_parse_wkt_polygon_with_hole():

--- a/update_geojson.py
+++ b/update_geojson.py
@@ -123,14 +123,22 @@ def load_existing_features(path: str = GEOJSON_PATH):
 
 
 def merge_features(existing, new):
-    """Combina listas de features evitando duplicados por nombre."""
-    names = {f.get("properties", {}).get("Nombre") for f in existing}
+    """Combina listas de features reemplazando por nombre si coincide."""
     merged = list(existing)
+    index_by_name = {}
+    for idx, feat in enumerate(merged):
+        name = feat.get("properties", {}).get("Nombre")
+        if name not in index_by_name:
+            index_by_name[name] = idx
+
     for feat in new:
         name = feat.get("properties", {}).get("Nombre")
-        if name not in names:
+        if name in index_by_name:
+            merged[index_by_name[name]] = feat
+        else:
+            index_by_name[name] = len(merged)
             merged.append(feat)
-            names.add(name)
+
     return merged
 
 def update_geojson():


### PR DESCRIPTION
## Summary
- update `merge_features` so new features replace existing ones with the same name
- update tests for new merge behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486b0198a8832e962edbf8ccecb3ac